### PR TITLE
Extend rust workflow to include additional checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Run formatting checks
+      run: cargo fmt --verbose --all -- --check
+    - name: Run clippy checks
+      run: cargo clippy --verbose --no-deps --all-targets --all-features -- -D warnings
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Add clippy and formatting checks.
This runs the cargo clippy and cargo fmt commands on the repository.